### PR TITLE
feat: upgrades on playlist page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myrandomicplaylist",
-  "version": "3.3.3",
+  "version": "3.4.0",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -8,8 +8,9 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.36",
+    "@fortawesome/free-regular-svg-icons": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",
-    "@fortawesome/vue-fontawesome": "^3.0.0-5",
+    "@fortawesome/vue-fontawesome": "^3.0.3",
     "@vue/cli": "^4.5.15",
     "@vue/cli-service-global": "^4.5.15",
     "axios": "^0.25.0",

--- a/src/components/FloatMenu.vue
+++ b/src/components/FloatMenu.vue
@@ -5,15 +5,16 @@ import VueBasicAlert from 'vue-basic-alert'
 
 const emit = defineEmits([
     'update-menu-opened',
-    'force-refresh'
+    'force-refresh',
+    'remove-track'
 ])
 const { addTracksToPlaylist, removeTracksOfPlaylist } = useGeneral()
 const { getPlaylists, executePlaylist } = useProfile()
 
 const ALERT_OPTIONS = { 
     iconSize: 35,
-    iconType: 'solid', // Icon styles: now only 2 styles 'solid' and 'regular'
-    position: 'top right' // Position of the alert 'top right', 'top left', 'bottom left', 'bottom right'
+    iconType: 'solid',
+    position: 'top right'
   }
 const alert = ref(null)
 
@@ -42,7 +43,6 @@ const menuOpened = computed(() => {
 });
 
 const menuData = computed(() => {
-    console.log(props.menuData)
     return props.menuData;
 });
 
@@ -60,9 +60,9 @@ const selectPlaylist = async(playlistId) => {
         const { status } = await addTracksToPlaylist(playlistId, formData)
         if (status === 201) {
             alert.value.showAlert(
-                'success', // There are 4 types of alert: success, info, warning, error
-                'Song added!', // Message of the alert
-                'Alright', // Header of the alert
+                'success',
+                'Song added!',
+                'Alright',
                 ALERT_OPTIONS
             )
             closeMenu()
@@ -80,9 +80,9 @@ const executeTrack = async(track) => {
       const { status } = await executePlaylist(formData)
       if (status != 204){
         alert.value.showAlert(
-            'error', // There are 4 types of alert: success, info, warning, error
-            error.response.data.error.message, // Message of the alert
-            'Ops', // Header of the alert
+            'error',
+            error.response.data.error.message,
+            'Ops',
             ALERT_OPTIONS
         )
         return
@@ -91,9 +91,9 @@ const executeTrack = async(track) => {
     }catch(error){
       console.log(error.response)
       alert.value.showAlert(
-        'error', // There are 4 types of alert: success, info, warning, error
-        error.response.data.error.message, // Message of the alert
-        'Ops', // Header of the alert
+        'error',
+        error.response.data.error.message,
+        'Ops',
         ALERT_OPTIONS
       )
     }
@@ -109,13 +109,13 @@ const removeTrack = async() => {
         const { status } = await removeTracksOfPlaylist(menuData.value.playlist.id, formData)
         if (status === 200) {
             alert.value.showAlert(
-                'success', // There are 4 types of alert: success, info, warning, error
-                'Song removed!', // Message of the alert
-                'Alright', // Header of the alert
+                'success',
+                'Song removed!',
+                'Alright',
                 ALERT_OPTIONS
             )
+            emit('remove-track', menuData.value.track.uri)
             closeMenu()
-            emit('force-refresh', true)
         }
     }catch(error){
       console.log(error)

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -12,6 +12,7 @@
     const step = ref(null)
     const menuData = ref(null)
     const refresh = ref(null)
+    const removeTrackRef = ref(null)
 
     const currentData = computed(() => {
         return floatPlayerData.value;
@@ -26,6 +27,10 @@
 
     const forceRefresh = computed(() => {
         return refresh.value;
+    })
+
+    const removeTrack = computed(() => {
+        return removeTrackRef.value;
     })
 
     const getUserProfile = async() => {
@@ -46,6 +51,10 @@
         forceRefresh: {
             type: Boolean,
             default: false,
+        },
+        removeTrack: {
+            type: String,
+            default: ''
         }
     });
 
@@ -63,6 +72,10 @@
 
     const onForceRefresh = (value) => {
         refresh.value = value
+    }
+
+    const onRemoveTrack = (value) => {
+        removeTrackRef.value = value
     }
 
     setInterval(async () => {
@@ -96,15 +109,18 @@
         :user-data="user"
         @update-menu-opened="onUpdateMenuOpened" 
         @force-refresh="onForceRefresh"
+        @remove-track="onRemoveTrack"
     />
     <router-view 
         :user-data="user" 
         :step-data="step" 
         :menu-opened="menuOpened" 
         :force-refresh="forceRefresh"
+        :remove-track="removeTrack"
         @update-step-data="onUpdateStepData" 
         @update-menu-opened="onUpdateMenuOpened" 
         @update-menu-data="onUpdateMenuData" 
         @force-refresh="onForceRefresh"
+        @remove-track="onRemoveTrack"
     />
 </template>

--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ import {
     faMusic,
     faTrash,
     faHeart,
+    faSync
 } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome"
 
@@ -57,6 +58,7 @@ library.add(
     faMusic,
     faTrash,
     faHeart,
+    faSync
 )
 
 const app  = createApp(App)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.14.tgz#1221684955c44385f8af34f7240088b7dc08d19d"
   integrity sha512-eQi9rosGNVQFJyJWV0HCA5WZae/qWIQME7s8/j8DMvnylfBv62Pbu+zJ2eUDqNf2O4u3WB+OEXyfkpBoe194sg==
 
+"@fortawesome/fontawesome-common-types@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz#88da2b70d6ca18aaa6ed3687832e11f39e80624b"
+  integrity sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==
+
 "@fortawesome/fontawesome-common-types@^0.2.36":
   version "0.2.36"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
@@ -1093,6 +1098,13 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.3.0"
 
+"@fortawesome/free-regular-svg-icons@^6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz#cacc53bd8d832d46feead412d9ea9ce80a55e13a"
+  integrity sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.4.0"
+
 "@fortawesome/free-solid-svg-icons@^5.15.4":
   version "5.15.4"
   resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
@@ -1100,10 +1112,10 @@
   dependencies:
     "@fortawesome/fontawesome-common-types" "^0.2.36"
 
-"@fortawesome/vue-fontawesome@^3.0.0-5":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.2.tgz#1b2ec546caab790c38d3dcb38407485a70703dd2"
-  integrity sha512-xHVtVY8ASUeEvgcA/7vULUesENhD+pi/EirRHdMBqooHlXBqK+yrV6d8tUye1m5UKQKVgYAHMhUBfOnoiwvc8Q==
+"@fortawesome/vue-fontawesome@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.3.tgz#633e2998d11f7d4ed41f0d5ea461a22ec9b9d034"
+  integrity sha512-KCPHi9QemVXGMrfuwf3nNnNo129resAIQWut9QTAMXmXqL2ErABC6ohd2yY5Ipq0CLWNbKHk8TMdTXL/Zf3ZhA==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
Após remover uma música, apenas remover da lista, não chamar o endpoint para buscar todas novamente.
Colocado um botão para atualizar, e feito fizer isso, mantido o filtro atual.
Na ordenação, mantido após remover alguma música.
Na ordenação não buscar endpoint quando passar pelo filtro default.

closes #31 